### PR TITLE
Alex Vansteel: Code Challenge

### DIFF
--- a/docker/config/docker-compose.yaml
+++ b/docker/config/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-name: investifi-backend-coding-challenge
 services:
   investifi-backend-coding-challenge:
     container_name: investifi-backend-coding-challenge

--- a/docker/env/.env
+++ b/docker/env/.env
@@ -1,4 +1,5 @@
 AWS_ACCESS_KEY_ID=testing123
 AWS_SECRET_ACCESS_KEY=supersecretkey
 AWS_REGION=us-west-1
+AWS_DEFAULT_REGION=us-west-1
 DYNAMO_ENDPOINT=http://db:8003

--- a/makefile
+++ b/makefile
@@ -1,15 +1,18 @@
 # This command only works if a container is running
+
+# ubuntu system requires the use of `docker-compose` and not `docker compose`
+
 bash:
-	docker compose -f ./docker/config/docker-compose.yaml run investifi-backend-coding-challenge bash
+	docker-compose -f ./docker/config/docker-compose.yaml run investifi-backend-coding-challenge bash
 
 destroy:
 	docker system prune -a --volumes
 
 run:
-	docker compose -f ./docker/config/docker-compose.yaml up --build
+	docker-compose -f ./docker/config/docker-compose.yaml up --build
 
 stop:
-	docker compose -f ./docker/config/docker-compose.yaml down -v --remove-orphans
+	docker-compose -f ./docker/config/docker-compose.yaml down -v --remove-orphans
 
 run-testsuite:
-	docker compose -f ./docker/config/docker-compose.yaml run investifi-backend-coding-challenge python -m pytest
+	docker-compose -f ./docker/config/docker-compose.yaml run investifi-backend-coding-challenge python -m pytest

--- a/src/api.py
+++ b/src/api.py
@@ -1,4 +1,12 @@
-from fastapi import FastAPI
+import boto3
+
+from botocore.exceptions import ClientError
+from fastapi import FastAPI, HTTPException
+
+from src.model import User, RecurringOrder, RecurringOrderFrequencyEnum, RecurringOrderCurrencyEnum
+
+
+recurring_order_table = RecurringOrder.__table_name__
 
 
 app = FastAPI(
@@ -15,19 +23,37 @@ def hello_world():
     return {"hello": "world"}
 
 
-@app.get("/recurring-orders")
-def get_recurring_orders():
+@app.get("/recurring-orders/{user_id}")
+def get_recurring_orders(user_id: str):
     """
     TODO
     # Requirements:
     # The GET route should accept a User ID and return only said users recurring orders
     # if no ID is provided, an error should be raised.
     """
-    return {}
+    
+    dynamodb_client = boto3.client('dynamodb')
+
+    key_condition_expression = 'hash_key=:hash_key'
+    filter_expression = 'not contains(:range_key, range_key)'
+    expression_values = {':hash_key': {'S': f'User#{user_id}'},
+                         ':range_key': {'S': 'details'}}
+
+    dynamodb_response = dynamodb_client.query(
+        TableName=recurring_order_table,
+        KeyConditionExpression=key_condition_expression,
+        FilterExpression=filter_expression,
+        ExpressionAttributeValues=expression_values,
+    )
+    
+    if recurring_orders := dynamodb_response.get('Items'):
+        return recurring_orders
+    else:
+        raise HTTPException(status_code=404, detail=str('no recurring orders found'))
 
 
 @app.post("/recurring-orders")
-def post_recurring_orders():
+def post_recurring_orders(recurring_order: RecurringOrder):
     """
     TODO
     Requirements:
@@ -38,4 +64,26 @@ def post_recurring_orders():
     A recurring order must have a USD amount greater than 0
     A recurring order needs to be associated with a specifc user.
     """
-    return {}
+    
+    dynamodb_client = boto3.client('dynamodb')
+    
+    # low cost and fast query on index to see if recording for user with the currency and frequency pair 
+    key_condition_expression = f'hash_key=:hash_key AND contains(:range_key, {recurring_order.currency}) AND contains(:range_key, {recurring_order.frequency})'
+    expression_values = {':hash_key': {'S': recurring_order.hash_key},
+                         ':range_key': {'S': recurring_order.range_key}}
+
+    dynamodb_response = dynamodb_client.query(
+        TableName=recurring_order_table,
+        KeyConditionExpression=key_condition_expression,
+        ExpressionAttributeValues=expression_values,
+    )
+    
+    if recurring_order := dynamodb_response.get('Item'):
+      raise HTTPException(status_code=422, detail='record already exists for user and currency')
+    else:
+        try:
+            dynamodb_client.put(Item=recurring_order.dict())
+        except ClientError as e:
+            raise HTTPException(status=500, detail=str(e))
+            
+    return recurring_order

--- a/src/model.py
+++ b/src/model.py
@@ -1,8 +1,11 @@
 import os
+import uuid
+
 from abc import abstractmethod
 from dyntastic import Dyntastic
-from pydantic import BaseModel, Field
-from typing import Optional
+from enum import Enum
+from pydantic import BaseModel, Field, validator, root_validator
+from typing import Optional, ClassVar, Dict
 
 
 class DynamoDbModelBase(Dyntastic):
@@ -33,12 +36,65 @@ will apply to this file.
 class UserInfo(BaseModel):
     first_name: str
     last_name: str
+    
+    account_number: str
+    routing_number: str
 
 
 class User(DynamoDbModelBase):
     __table_name__ = "User"
+    
+    entity_name: ClassVar[str] = 'User'
+    
+    hash_key_prefix: ClassVar[str] = f'{entity_name}#'
+    range_key_const: ClassVar[str] = 'details'
+    
+    range_key: str = Field(range_key_const, const=True)
+    
     info: Optional[UserInfo]
 
+    # Safety measure to format `hash_key` on class creation
+    # so it accepts either the full User#{uuid} or just uuid
+    @validator('pk', pre=True, check_fields=False, allow_reuse=True)
+    def _generate_user_hash_key(cls, value: str):
+        return f'{cls.hash_key_prefix}{value.split("#")[-1]}'
+
+
+class RecurringOrderCurrencyEnum(str, Enum):
+    BTC = 'BTC'  # Bitcoin
+    ETH = 'ETH'  # Ethereum
+
+
+class RecurringOrderFrequencyEnum(str, Enum):
+    DAILY = 'DAILY'
+    BI_MONTHLY = 'BI_MONTHLY'
+    
 
 class RecurringOrder(DynamoDbModelBase):
     __table_name__ = "RecurringOrder"
+    entity_name: ClassVar[str] = 'RecurringOrder'
+    
+    hash_key_prefix: ClassVar[str] = f'{User.entity_name}#'
+    range_key_prefix: ClassVar[str] = f'{entity_name}#'
+    
+    currency: RecurringOrderCurrencyEnum
+    frequency: RecurringOrderFrequencyEnum
+    amount: int = Field(gt=0)  # USD currenty int 1000 -> $10.00 to prevent rounding error issues and follow how most cores handle money values
+    
+    class Config:
+        use_enum_values = True 
+    
+    # Safety measure to format `hash_key` on class creation
+    # so it accepts either the full User#{uuid} or just uuid
+    @validator('hash_key', pre=True, check_fields=False)
+    def _format_recurring_order_hash_key(cls, value):
+        return f'{cls.hash_key_prefix}{value.split("#")[-1]}'
+
+    # Generates `range_key` on creation of new RecurringOrder
+    # ignores if validating existing
+    # uses root_validator to have access to other fields
+    @root_validator(pre=True)
+    def _generate_uuids(cls, values: Dict):
+        if not values.get('range_key'):
+            values['range_key'] = f'{cls.range_key_prefix}{uuid.uuid4()}#{values.get("currency")}#{values.get("frequency")}'
+        return values

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -1,8 +1,13 @@
+import uuid
+
 from fastapi.testclient import TestClient
 
 from test.helpers import InvestifiTestCase
 from src.api import app
+from src.model import User, RecurringOrder, RecurringOrderCurrencyEnum, RecurringOrderFrequencyEnum
 
+
+USER_ID = uuid.uuid4()
 
 class TestHelloWorldRoute(InvestifiTestCase):
     """
@@ -28,3 +33,103 @@ TODO [OPTIONAL]
 Write more tests for your work. These can be unit tests for specfic classes or
 integration tests that actually make api calls like the example above.
 """
+
+class TestModels(InvestifiTestCase):
+    # These are not actually needed since pydantic already does test coverate.
+    # This is mostly just for quick personal sanity check/reference during development.
+    
+    def test_user_model(self):
+        user_dict = {'hash_key': f'User#{USER_ID}',
+                     'info': {'first_name': 'Alex',
+                              'last_name': 'Vansteel',
+                              'account_number': '123456789',
+                              'routing_number': '987654321'}}
+        
+        user: User = User(**user_dict)
+        
+        self.assertEqual(user.hash_key, user_dict['hash_key'])
+        self.assertEqual(user.range_key, 'details')
+        self.assertEqual(user.info.first_name, user_dict['info']['first_name'])
+        self.assertEqual(user.info.last_name, user_dict['info']['last_name'])
+        self.assertEqual(user.info.account_number, user_dict['info']['account_number'])
+        self.assertEqual(user.info.routing_number, user_dict['info']['routing_number'])
+        
+    def test_recurring_order(self):
+        recurring_order_dict = {'hash_key': f'User#{USER_ID}',
+                                'currency': RecurringOrderCurrencyEnum.BTC,
+                                'frequency': RecurringOrderFrequencyEnum.DAILY,
+                                'amount': 1000}
+        
+        recurring_order: RecurringOrder = RecurringOrder(**recurring_order_dict)
+        
+        self.assertEqual(recurring_order.hash_key, recurring_order_dict['hash_key'])
+        self.assertIsNotNone(recurring_order.range_key)
+        self.assertEqual(recurring_order.currency, recurring_order_dict['currency'])
+        self.assertEqual(recurring_order.frequency, recurring_order_dict['frequency'])
+        self.assertEqual(recurring_order.amount, recurring_order_dict['amount'])
+        
+
+class TestRecurringOrdersRoutes(InvestifiTestCase):
+        
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.client = TestClient(app)
+        cls.url = "/recurring-orders"
+        
+    def test_post_recurring_orders_route(self):
+        body = {'hash_key': f'User#{USER_ID}',
+                'currency': RecurringOrderCurrencyEnum.BTC,
+                'frequency': RecurringOrderFrequencyEnum.DAILY,
+                'amount': 1000}
+        
+        response = self.client.post(self.url, json=body)
+        self.assertEqual(response.status_code, 200)
+        
+    def test_post_recurring_orders_zero_amount(self):
+        body = {'hash_key': f'User#{USER_ID}',
+                'currency': RecurringOrderCurrencyEnum.BTC,
+                'frequency': RecurringOrderFrequencyEnum.DAILY,
+                'amount': 0}
+        
+        response = self.client.post(self.url, json=body)
+        print(response.json())
+        self.assertEqual(response.status_code, 422)
+        msg = response.json()['detail'][0].get('msg')
+        self.assertEqual(msg, 'ensure this value is greater than 0')
+        
+    def test_post_recurring_orders_duplicate(self):
+        # ideally, I would take the time to set up fixtures in a conftest.py and pre-populate the tabels
+        body = {'hash_key': f'User#{USER_ID}',
+                'currency': RecurringOrderCurrencyEnum.BTC,
+                'frequency': RecurringOrderFrequencyEnum.DAILY,
+                'amount': 1000}
+        
+        response = self.client.post(self.url, json=body)
+        self.assertEqual(response.status_code, 200)
+        
+        body = {'hash_key': f'User#{USER_ID}',
+                'currency': RecurringOrderCurrencyEnum.BTC,
+                'frequency': RecurringOrderFrequencyEnum.DAILY,
+                'amount': 1000}
+        
+        response = self.client.post(self.url, json=body)
+        self.assertEqual(response.status_code, 422)
+        
+    def test_get_recurring_orders(self):
+        body = {'hash_key': f'User#{USER_ID}',
+                'currency': RecurringOrderCurrencyEnum.BTC,
+                'frequency': RecurringOrderFrequencyEnum.DAILY,
+                'amount': 1000}
+        self.client.post(self.url, json=body)
+        
+        body = {'hash_key': f'User#{USER_ID}',
+                'currency': RecurringOrderCurrencyEnum.ETH,
+                'frequency': RecurringOrderFrequencyEnum.BI_MONTHLY,
+                'amount': 10000}
+        self.client.post(self.url, json=body)
+        
+        response = self.client.get(f'{self.url}/{USER_ID}')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.content), 2)
+        


### PR DESCRIPTION
The first, and most important, step is to begin defining the models. This is something that I would want to start of as being a meeting between Product and Engineering to try and get as close as possible to define what fields are going to be needed for the first iteration of the models. 

I added `account_number` and `routing_number` to `UserInfo`. I would expect this to be required information for processing the `RecurringOrder`. I imagine that there is more information which would be stored on the `User`. 

For the `RecurringOrder`, I created Enums to manage the validation for viable currencies and frequencies.  Right  now, the only Enum values are the valid ones, using the Enums for validation. If there are more supported frequencies and/or currency combination for different things, then those could be added in the future. Added the `currency`, `frequency`, and `amount` fields with the validations for them there. Every core which I can remember, as well as every payment processor (such as Stripe) which I have interacted with have always required USD values to be `int` so that there are no possible rounding issues which could happen with `float`. 

Used `root_validator` for generating the `range_key` so that it will have access to the other field values before object creation. This is a trick which was used on a previous project, as well as the `hash_key` validator. The value of this is dependent on how many different models are stored in the same table and how many indices are needed. I view the `RecurringOrder` as a child of the `User`, so they would both share the same `hask_key` and the individual `RecurringOrders` would have their `range_keys` generated. 

The `get_recurring_orders` should be a pretty straight forward API call. I am used to standards where the `user_id` would be in the path for the GET, so I added it there. This could also be part of the body if that would fit with the rest of the API better. The `range_key` uses the user uuid, and then filter out for the default `details` added to guarantee the exclusion the `User` record and only retrieve the `RecurringOrders`. This could be changed based on how many different models are stored in the same tables.

The post uses a `query` on the dynamo table for the `hash_key` and checks if there are any `range_keys` which contain the `currency` and `frequency` pairing. This is a low cast and fast check since we are just using the keys, rather than trying to add conditions to the `put` statement. If additional checks need to be added that get more complicated, I would want to refactor this to use the conditionals on the `boto3.client.put`, but as it stands, there is little benefit, if any since the `pydantic` model handles all the other requirement validations on the fields. 

For the tests, this is where I started to run into some issues which I spent far longer trying to figure out on my own than I ever would have before reaching out for a second set of eyes. I also suspect that these issues might be connected to my local running on Ubuntu when this project was created on iOS (I have been burnt by some of these differences in the past). I was having configuration issues with the `helper.py` and AWS stuff not being set correctly in the docker image. It was not registering the region, but I was able to figure that out by adding an additional default value to the docker environment configs, but I was not able to figure out why the `AWS_ACCESS_KEY_ID` is not being set when the wrapper function that is supposed to be setting it is not working. I found a couple of different solutions online, but they were either already implemented or they did not work. 

### Possible Future Improvements
* Creating a `service` layer to remove all current and future DynamoDB calls out of the API endpoint layer. This would allow for increased readability and reuse of any queries. 
* It could also be beneficial to move the models into their own directory, and have each item class have it's own individual file for readability depending on how many different models and records are used by the service. 


### Change Summary

#### Docker and Make Files
##### `docker-compose.yaml`
* remove `version` and `name`
  * `version` top level element obsolete in 1.27.4 (https://docs.docker.com/reference/compose-file/version-and-name/)
  * `name` top level element should work according to above link, but it is throwing a conflicting error saying that there needs to be a version,  but if the version is present, it ignores it. Commenting out the name and allows the `make run` command to work. This might be an issue of using the Ubuntu OS instead of a iOS or Windows OS. Keeping the local like this to proceed, would reach out and discuss with whoever set up at a latter time to see if there is a better resolution.

##### `docker/env/.env`
* Add `AWS_DEFAULT_REGION` environment variable because no region was being set in my local. This suggestion fixed the issue.

##### `makefile`
* Docker requires the use of `docker-compose` on an Ubuntu OS.

#### `api.py`
* add `boto3` and model imports
* add dynamodb query for `get_recurring_orders`
* add dynamodb query for `post_recurring_orders`
  * add query to check for existing `RecurringOrder` for user with the same currency and duration before creating item

#### `model.py`
* add `uuid` import
##### `User`
* add `account number` and `routing_number` to `UserInfo`
* add definitions for primary and secondary keys for `User`
* add `validator` to `hash_key` so object can be created with just the `uuid` without any prefixes

##### `RecurringOrder`
* add `RecurringOrderCurrencyEnum`
* add `RecurringOrderFrequencyEnum`
* add `currency`, `frequency`, and `amount` fields
  * add greater than zero validation to `amount` and enums to `currency` and `frequency`
* add `validator` on `hash_key`
* add `root_validator` for generating `range_key` if it does not exist on class creation

#### Tests
* add tests for models during early development. to be removed later
* add `test_post_recurring_orders_route`
* add `test_post_recurring_orders_zero_amount`
* add ``test_post_recurring_orders_duplicate`
* add `test_get_recurring_orders`